### PR TITLE
Ubuntu 18.04/20.04 LTS x86 版で CUDA のインストールに失敗する問題を修正

### DIFF
--- a/build/ubuntu-18.04_x86_64/Dockerfile
+++ b/build/ubuntu-18.04_x86_64/Dockerfile
@@ -132,7 +132,8 @@ RUN set -ex \
   && apt-get install -y software-properties-common \
   && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin \
   && mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600 \
-  && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub \
-  && add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" \
+  && wget http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda-repo-ubuntu1804-11-0-local_11.0.2-450.51.05-1_amd64.deb \
+  && dpkg -i cuda-repo-ubuntu1804-11-0-local_11.0.2-450.51.05-1_amd64.deb \
+  && apt-key add /var/cuda-repo-ubuntu1804-11-0-local/7fa2af80.pub \
   && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get -y install cuda-11.0 clang-10
+  && DEBIAN_FRONTEND=noninteractive apt-get -y install cuda clang-10

--- a/build/ubuntu-20.04_x86_64/Dockerfile
+++ b/build/ubuntu-20.04_x86_64/Dockerfile
@@ -130,9 +130,10 @@ RUN \
 RUN set -ex \
   && apt-get update \
   && apt-get install -y software-properties-common \
-  && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin \
-  && mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600 \
-  && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub \
-  && add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" \
+  && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin \
+  && mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 \
+  && wget http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda-repo-ubuntu2004-11-0-local_11.0.2-450.51.05-1_amd64.deb \
+  && dpkg -i cuda-repo-ubuntu2004-11-0-local_11.0.2-450.51.05-1_amd64.deb \
+  && apt-key add /var/cuda-repo-ubuntu2004-11-0-local/7fa2af80.pub \
   && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get -y install cuda-11.0 clang-10
+  && DEBIAN_FRONTEND=noninteractive apt-get -y install cuda clang-10


### PR DESCRIPTION
## 結論

最後にビルドできていた CUDA 11.0.2 にバージョンを固定することで、問題を解決。

以下、考察と検証結果。

## 変更の背景

* Clang 10 は CUDA 7.0 から 10.1 までしかサポートしていない
  * https://gist.github.com/ax3l/9489132#clang--x-cuda
* NVIDIA の apt repository は既に 11.1 まで進んでおり、10.1 はインストールできない。チェックした範囲では、11.0.1, 11.0.2, 11.0.3, 11.1.0 しかインストールできない。
* 現状依存関係でエラーになっているが、これを解消しても CUDA 11.1 ではコンパイルできないことを確認した
  * `clang: error: cannot find libdevice for sm_52. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.` というエラーが出る
  * `-nocudalib` オプションを追加するとビルドは完了するが、最適化されたバイナリが出力されないのではないかという懸念がある（動作確認環境がないので、未検証）

上記のことから、CUDA 10.1 を明示的にインストールした方が将来的にもビルドが壊れる心配もなくなるので、良いのではないと考えた。

CUDA 10.1 のインストール方法は、下記の公式サイトから取得した。

https://developer.nvidia.com/cuda-10.1-download-archive-update2?target_os=Linux&target_arch=x86_64&target_distro=Ubuntu&target_version=1804&target_type=deblocal

## CUDA 10.1 でビルドできるかどうか => ダメだった

- [x] Ubuntu 18.04 LTS
- [ ] Ubuntu 20.04 LTS => CUDA 10.1 がインストールできない (https://github.com/hakobera/momo/pull/2/checks?check_run_id=1271452018)

## CUDA 11.0.2 を検証 => 1番最後にビルドできていた時のバージョン

CUDA 11.0.3 は壊れていて、CUDA 11.1.0 ではビルドできないため。

- [x] Ubuntu 18.04 LTS
- [x] Ubuntu 20.04 LTS